### PR TITLE
feat: use src folder as page path for support _mock etc...

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@
 // - https://umijs.org/plugin/develop.html
 import { join } from 'path';
 
+process.env.PAGES_PATH = 'src';
+
 export default function (api) {
   const { paths } = api;
 
@@ -10,7 +12,7 @@ export default function (api) {
       ...memo,
       routes: [{
         path: '/',
-        component: '../src/index',
+        component: 'index',
       }],
     };
   });


### PR DESCRIPTION
区块开发时通过 PAGES_PATH 指定 src 为 page 目录，这样使得支持 src 下面可以添加 _mock locales 这样的相关文件。