### PR TITLE
fix: move @ant-design/pro-layout to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "test": "umi-test"
   },
   "devDependencies": {
-    "@ant-design/pro-layout": "^4.3.0",
     "umi-plugin-react": "^1.9.7",
     "umi-request": "^1.0.8",
     "umi-test": "^1.2.2",
@@ -38,6 +37,7 @@
     "layouts"
   ],
   "dependencies": {
+    "@ant-design/pro-layout": "^4.3.0",
     "path-to-regexp": "^2.4.0",
     "uppercamelcase": "^3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "url": "https://github.com/umijs/umi-plugin-block-dev/issues"
   },
   "peerDependencies": {
-    "umi": "2.x"
+    "umi": "2.x",
+    "@ant-design/pro-layout": "^4.3.0"
   },
   "main": "lib/index.js",
   "scripts": {
@@ -37,7 +38,6 @@
     "layouts"
   ],
   "dependencies": {
-    "@ant-design/pro-layout": "^4.3.0",
     "path-to-regexp": "^2.4.0",
     "uppercamelcase": "^3.0.0"
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1061968/60514877-fe1d1d00-9d0c-11e9-898a-d4e4c29a6640.png)

放在 devDependencies 中的话并不会被安装，会导致运行时报错。